### PR TITLE
Update CI image

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -35,7 +35,7 @@ Vagrant.configure(2) do |config|
   config.vm.define :centos70 do |c|
     c.vm.box = "centos/7"
     c.vm.provider :digital_ocean do |provider, override|
-      provider.image = "centos-7-0-x64"
+      provider.image = "centos-7-x64"
     end
     c.vm.hostname  = 'itamae-consul-centos70'
     c.vm.hostname  += "-#{ENV['WERCKER_RUN_ID']}" if ENV['WERCKER_RUN_ID']


### PR DESCRIPTION
https://app.wercker.com/sue445/itamae-plugin-recipe-consul/runs/build-centos70/59d3b5938e888f0001b27d75?step=59d3b59da155ed000105a84a

```
+ vagrant up centos70 --provider=digital_ocean
Bringing machine 'centos70' up with 'digital_ocean' provider...
==> centos70: Using existing SSH key: wercker-itamae-plugin-recipe-consul
There was an issue with the request made to the DigitalOcean
API at:

Path: /v2/droplets
URI Params: {:size=>"512MB", :region=>"nyc3", :image=>"centos-7-0-x64", :name=>"itamae-consul-centos70-59d3b5938e888f0001b27d75", :ssh_keys=>[1874082], :private_networking=>false, :ipv6=>false}

The response status from the API was:

Status: 422
Response: {"id"=>"unprocessable_entity", "message"=>"You specified an invalid image for Droplet creation."}
```